### PR TITLE
Fixed Crash with Hotbar Swap

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -59,8 +59,8 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:EnderStorage:1.7.0:dev")
     compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.13.3-GTNH:dev")
     compileOnly("com.github.GTNewHorizons:CodeChickenCore:1.4.1:dev")
-    compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.7.15-GTNH:dev")
-    devOnlyNonPublishable("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.61:dev")
+    compileOnly("com.github.GTNewHorizons:NotEnoughItems:2.7.18-GTNH:dev")
+    devOnlyNonPublishable("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.67:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:Botania:1.12.3-GTNH:dev")
 
 


### PR DESCRIPTION
Battle Gear crashed when pressing Alt, so a check has now been added to only look for the hotbar