### PR TITLE
Fix #64

### DIFF
--- a/src/main/java/com/cleanroommc/bogosorter/ShortcutHandler.java
+++ b/src/main/java/com/cleanroommc/bogosorter/ShortcutHandler.java
@@ -42,9 +42,6 @@ public class ShortcutHandler {
     public static void moveItemStack(EntityPlayer player, Container container, ISlot slot, boolean emptySlot,
         int amount) {
         if (slot == null || slot.bogo$getStack() == null) return;
-        if (!slot.bogo$canTakeStack(player)) {
-            return;
-        }
         ItemStack stack = slot.bogo$getStack();
         amount = Math.min(amount, stack.getMaxStackSize());
         ItemStack toInsert = stack.copy();

--- a/src/main/java/com/cleanroommc/bogosorter/mixins/early/minecraft/SlotMixin.java
+++ b/src/main/java/com/cleanroommc/bogosorter/mixins/early/minecraft/SlotMixin.java
@@ -114,7 +114,7 @@ public abstract class SlotMixin implements ISlot {
     // Temporary fix #45 until we determine the cause of the issue
     @ModifyReturnValue(method = "canTakeStack", at = @At("RETURN"))
     private boolean modifyCanTakeStack(boolean original, EntityPlayer p_82869_1_) {
-        if (!SetCanTakeStack) {
+        if (p_82869_1_.worldObj.isRemote && !SetCanTakeStack) {
             return false;
         }
         return original;


### PR DESCRIPTION
SetCanTakeStack is only set on the client.

Removed canTakeStack check from ctrl shortcut as its handled in the mixin