### PR TITLE
Add config option to specify custom dropoff targets

### DIFF
--- a/src/main/java/com/cleanroommc/bogosorter/common/config/BogoSorterConfig.java
+++ b/src/main/java/com/cleanroommc/bogosorter/common/config/BogoSorterConfig.java
@@ -49,6 +49,7 @@ public class BogoSorterConfig {
         general.addProperty("dropoffChatMessage", DropOffHandler.dropoffChatMessage);
         general.addProperty("dropoffQuotaInMS", DropOffHandler.dropoffQuotaInMS);
         general.addProperty("dropoffPacketThrottleInMS", DropOffHandler.dropoffPacketThrottleInMS);
+        general.addProperty("dropoffTargetNames", DropOffHandler.dropoffTargetNames);
         general.addProperty("dropoffButtonShow", DropOffButtonHandler.showButton);
         general.addProperty("dropoffButtonX", DropOffButtonHandler.buttonX);
         general.addProperty("dropoffButtonY", DropOffButtonHandler.buttonY);
@@ -103,6 +104,7 @@ public class BogoSorterConfig {
             DropOffHandler.dropoffChatMessage = JsonHelper.getBoolean(general, true, "dropoffChatMessage");
             DropOffHandler.dropoffQuotaInMS = JsonHelper.getInt(general, 1, "dropoffQuotaInMS");
             DropOffHandler.dropoffPacketThrottleInMS = JsonHelper.getInt(general, 500, "dropoffPacketThrottleInMS");
+            DropOffHandler.dropoffTargetNames = JsonHelper.getString(general, "*Chest*, *Barrel*, *Drawer*, *Crate*", "dropoffTargetNames");
             DropOffButtonHandler.showButton = JsonHelper.getBoolean(general, true, "dropoffButtonShow");
             DropOffButtonHandler.buttonX = JsonHelper.getInt(general, 160, "dropoffButtonX");
             DropOffButtonHandler.buttonY = JsonHelper.getInt(general, 5, "dropoffButtonY");

--- a/src/main/java/com/cleanroommc/bogosorter/common/dropoff/DropOffHandler.java
+++ b/src/main/java/com/cleanroommc/bogosorter/common/dropoff/DropOffHandler.java
@@ -21,6 +21,7 @@ public class DropOffHandler {
     public static boolean dropoffChatMessage = true;
     public static int dropoffQuotaInMS = 1;
     public static int dropoffPacketThrottleInMS = 500;
+    public static String dropoffTargetNames = "*Chest*, *Barrel*, *Drawer*, *Crate*";
 
     public DropOffHandler(InventoryManager inventoryManager) {
         this.inventoryManager = inventoryManager;

--- a/src/main/java/com/cleanroommc/bogosorter/common/dropoff/InventoryManager.java
+++ b/src/main/java/com/cleanroommc/bogosorter/common/dropoff/InventoryManager.java
@@ -175,10 +175,7 @@ public class InventoryManager {
     }
 
     private boolean isInventoryNameValid(String name) {
-        List<String> containerNames = new ArrayList<>();
-        containerNames.add("*Chest*");
-        containerNames.add("*Barrel*");
-        containerNames.add("*Drawer*");
+        String[] containerNames = DropOffHandler.dropoffTargetNames.split(",");
 
         for (String containerName : containerNames) {
             String regex = containerName.replace("*", ".*")


### PR DESCRIPTION
Adds a configurable comma delimited list of container names instead of the hard-coded list.

Also adds `*Crate*` to the default list of dropoff targets, for NTM compatibility.

Does not include GUI changes, the config must be edited outside of the game.