### PR TITLE
Fixes issue with dropoffTargetNames not working for localized games

### DIFF
--- a/src/main/java/com/cleanroommc/bogosorter/common/dropoff/InventoryManager.java
+++ b/src/main/java/com/cleanroommc/bogosorter/common/dropoff/InventoryManager.java
@@ -1,5 +1,7 @@
 package com.cleanroommc.bogosorter.common.dropoff;
 
+import static com.cleanroommc.bogosorter.common.dropoff.LocalizationHelper.getDisplayNameEnglish;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -145,8 +147,8 @@ public class InventoryManager {
         if (inventory instanceof TileEntity) {
             TileEntity entity = (TileEntity) inventory;
             ItemStack itemStack = new ItemStack(entity.getBlockType(), 1, entity.getBlockMetadata());
-
-            return itemStack.getDisplayName();
+            // Always return English name for blocks even if the game is in another language
+            return getDisplayNameEnglish(itemStack);
         }
 
         return StatCollector.translateToLocal(inventory.getInventoryName());

--- a/src/main/java/com/cleanroommc/bogosorter/common/dropoff/LocalizationHelper.java
+++ b/src/main/java/com/cleanroommc/bogosorter/common/dropoff/LocalizationHelper.java
@@ -23,7 +23,7 @@ public class LocalizationHelper {
     /**
      * Gets the English translation (name) for an ItemStack, checking mod translations first.
      */
-    public static String getEnglishNameForItemStack(ItemStack itemStack) {
+    public static String getDisplayNameEnglish(ItemStack itemStack) {
         String unlocalizedName = itemStack.getUnlocalizedName() + ".name";
 
         // Check each mod's language file for the translation


### PR DESCRIPTION
Fixes #80

LocalizationHelper was added to always get the ItemStack name in English, as this is needed for Dropoff to correctly identify which block to use.