### PR TITLE
return empty string instead of crashing

### DIFF
--- a/src/main/java/com/cleanroommc/bogosorter/common/sort/ItemCompareHelper.java
+++ b/src/main/java/com/cleanroommc/bogosorter/common/sort/ItemCompareHelper.java
@@ -44,13 +44,13 @@ public class ItemCompareHelper {
 
     public static String getMod(ItemStack item) {
         String loc = item.getItem().delegate.name();
-        if (loc == null) throw new IllegalStateException("Item doesn't have a registry name!");
+        if (loc == null) return "";
         return loc.split(":")[0].toLowerCase();
     }
 
     public static String getId(ItemStack item) {
         String loc = item.getItem().delegate.name();
-        if (loc == null) throw new IllegalStateException("Item doesn't have a registry name!");
+        if (loc == null) return "";
         return loc.split(":")[1].toLowerCase();
     }
 


### PR DESCRIPTION
The crash (usually with minecraft doors that are modified by MalisisDoors and EFR)
```
[19:21:56] [Server thread/ERROR] [FML]: There was a critical exception handling a packet on channel bogosorter
java.lang.IllegalStateException: Item doesn't have a registry name!
    at Launch//com.cleanroommc.bogosorter.common.sort.ItemCompareHelper.getMod(ItemCompareHelper.java:47) ~[ItemCompareHelper.class:?]
    at Launch//com.cleanroommc.bogosorter.common.sort.ItemCompareHelper.compareMod(ItemCompareHelper.java:95) ~[ItemCompareHelper.class:?]
    at Launch//com.cleanroommc.bogosorter.api.SortRule.compare(SortRule.java:50) ~[SortRule.class:?]
    at Launch//com.cleanroommc.bogosorter.common.sort.SortHandler.lambda$new$0(SortHandler.java:115) ~[SortHandler.class:?]
    ```