### PR TITLE
Add tooltip on inventory buttons

### DIFF
--- a/src/main/java/com/cleanroommc/bogosorter/common/dropoff/DropOffInvButton.java
+++ b/src/main/java/com/cleanroommc/bogosorter/common/dropoff/DropOffInvButton.java
@@ -1,6 +1,6 @@
 package com.cleanroommc.bogosorter.common.dropoff;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -10,8 +10,11 @@ import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.resources.I18n;
+import net.minecraft.client.settings.GameSettings;
+import net.minecraft.util.EnumChatFormatting;
 
 import com.cleanroommc.bogosorter.BogoSorter;
+import com.cleanroommc.bogosorter.ClientEventHandler;
 import com.cleanroommc.bogosorter.common.config.BogoSorterConfig;
 import com.cleanroommc.bogosorter.common.network.CDropOff;
 import com.cleanroommc.bogosorter.common.network.NetworkHandler;
@@ -116,14 +119,17 @@ public class DropOffInvButton extends GuiButton {
         // dont play click sound
     }
 
-    private static final List<String> TOOLTIP = Arrays.asList(
-        I18n.format("key.dropoff.tooltip")
-            .split(System.lineSeparator()));
-
     public void drawTooltip(int mouseX, int mouseY) {
         if (this.enabled && this.field_146123_n) {
+            final List<String> tooltipLines = new ArrayList<>(3);
+            tooltipLines.add(I18n.format("key.dropoff.tooltip1"));
+            tooltipLines.add(I18n.format("key.dropoff.tooltip2"));
+            tooltipLines.add(
+                EnumChatFormatting.DARK_GRAY + I18n.format("key.tooltip.keybind")
+                    + " : "
+                    + GameSettings.getKeyDisplayString(ClientEventHandler.dropoffKey.getKeyCode()));
             GuiScreen guiScreen = Objects.requireNonNull(Minecraft.getMinecraft().currentScreen);
-            guiScreen.func_146283_a(TOOLTIP, mouseX, mouseY);
+            guiScreen.func_146283_a(tooltipLines, mouseX, mouseY);
         }
     }
 }

--- a/src/main/java/com/cleanroommc/bogosorter/common/sort/ButtonHandler.java
+++ b/src/main/java/com/cleanroommc/bogosorter/common/sort/ButtonHandler.java
@@ -1,6 +1,7 @@
 package com.cleanroommc.bogosorter.common.sort;
 
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 import net.minecraft.client.Minecraft;
@@ -8,7 +9,9 @@ import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.resources.I18n;
+import net.minecraft.client.settings.GameSettings;
 import net.minecraft.inventory.Container;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.client.event.GuiScreenEvent;
 
 import org.jetbrains.annotations.NotNull;
@@ -151,10 +154,17 @@ public class ButtonHandler {
         public void drawTooltip(int mouseX, int mouseY) {
             if (this.enabled && this.field_146123_n) {
                 GuiScreen guiScreen = Objects.requireNonNull(Minecraft.getMinecraft().currentScreen);
-                guiScreen.func_146283_a(
-                    Collections.singletonList(I18n.format(this.sort ? "key.sort" : "key.sort_config")),
-                    mouseX,
-                    mouseY);
+                final List<String> tooltipLines = new ArrayList<>(2);
+                if (this.sort) {
+                    tooltipLines.add(I18n.format("key.sort"));
+                    tooltipLines.add(
+                        EnumChatFormatting.DARK_GRAY + I18n.format("key.tooltip.keybind")
+                            + " : "
+                            + GameSettings.getKeyDisplayString(ClientEventHandler.sortKey.getKeyCode()));
+                } else {
+                    tooltipLines.add(I18n.format("key.sort_config"));
+                }
+                guiScreen.func_146283_a(tooltipLines, mouseX, mouseY);
             }
         }
     }

--- a/src/main/resources/assets/bogosorter/lang/en_US.lang
+++ b/src/main/resources/assets/bogosorter/lang/en_US.lang
@@ -2,7 +2,9 @@ key.categories.bogosorter=Inventory Bogo Sorter
 key.sort_config=Open Sort Config
 key.sort=Sort Inventory
 key.dropoff=Dropoff
-key.dropoff.tooltip=Dropoff To Nearby Inventories %nControl + Drag To Move
+key.dropoff.tooltip1=Dropoff To Nearby Inventories
+key.dropoff.tooltip2=Control + Drag To Move
+key.tooltip.keybind=Keybind
 
 bogosort.gui.title=Sort Config
 bogosort.gui.tab.general.name=General


### PR DESCRIPTION
add a tooltip on inventory buttons to inform users that a keybind is available if they want

![image](https://github.com/user-attachments/assets/b553fa56-b0ff-43fd-934c-f42a8e6b609f)
![image](https://github.com/user-attachments/assets/1bbf84a9-11a8-47e1-951c-fa4aad4fc1e7)