### PR TITLE
Prevent splitting of items with max stack size of 1 during sorting

### DIFF
--- a/src/main/java/com/cleanroommc/bogosorter/common/config/BogoSorterConfig.java
+++ b/src/main/java/com/cleanroommc/bogosorter/common/config/BogoSorterConfig.java
@@ -34,6 +34,13 @@ public class BogoSorterConfig {
     @Config.Sync
     public static int autoRefillDamageThreshold;
 
+    @Config.DefaultBoolean(true)
+    @Config.Comment({ "If enabled, items with max stack size of 1 (e.g., tools, armor, etc.)",
+        "will not be split when sorting. This helps avoid cluttering the inventory with duplicate single-item stacks." })
+    @Config.LangKey("bogosorter.config.preventSplit")
+    @Config.Sync
+    public static boolean preventSplit;
+
     @Config.DefaultString("#FFFFFFFF")
     @Config.Comment("The color of the sort button in hex format (e.g. #FFFFFFFF or 0xFFFFFFFF).")
     @Config.LangKey("bogosorter.config.button.color")

--- a/src/main/java/com/cleanroommc/bogosorter/common/sort/SortHandler.java
+++ b/src/main/java/com/cleanroommc/bogosorter/common/sort/SortHandler.java
@@ -360,6 +360,7 @@ public class SortHandler {
     // Prevents splitting of non-stackable items (e.g., tools, armor) with stack size > 1
     // to avoid filling the inventory unnecessarily.
     private static boolean preventSplit(ItemStack stack) {
+        if (!BogoSorterConfig.preventSplit) return false;
         return stack.getMaxStackSize() == 1;
     }
 }

--- a/src/main/resources/assets/bogosorter/lang/en_US.lang
+++ b/src/main/resources/assets/bogosorter/lang/en_US.lang
@@ -112,4 +112,5 @@ bogosorter.config.hotbarsort.enable=Enable hotbar sort
 bogosorter.config.hotbarswap.enable=Enable hotbar swap
 bogosorter.config.autorefill.enable=Enable auto-refill
 bogosorter.config.autorefill.damage_threshold=Auto-refill damage threshold
+bogosorter.config.preventSplit=Prevent Split for Unstackable Items
 bogosorter.config.button.color=Sort button color


### PR DESCRIPTION
closes https://github.com/GTNewHorizons/InventoryBogoSorter/issues/109

Add config option to prevent splitting unstackable items during sorting

Items such as tools and armor that have a max stack size of 1 but a stack size > 1
are now placed whole without being split, preserving their integrity and avoiding
inventory clutter.

Also fixed a bug where items above their max stack size were voided when the inventory
was full during sorting.

