### PR TITLE
Add option to sort the player's inventory with the keybind while the GUI is close

### DIFF
--- a/src/main/java/com/cleanroommc/bogosorter/common/config/BogoSorterConfig.java
+++ b/src/main/java/com/cleanroommc/bogosorter/common/config/BogoSorterConfig.java
@@ -17,10 +17,15 @@ public class BogoSorterConfig {
     @Config.LangKey("bogosorter.config.sort.sound")
     public static String sortSound;
 
-    @Config.DefaultBoolean(true)
+    @Config.DefaultBoolean(false)
     @Config.Comment("Enable the hotbar sort feature.")
     @Config.LangKey("bogosorter.config.hotbarsort.enable")
     public static boolean enableHotbarSort;
+
+    @Config.DefaultBoolean(true)
+    @Config.Comment("Sort inventory when keybind is pressed while no GUI is open.")
+    @Config.LangKey("bogosorter.config.noguisort.enable")
+    public static boolean enableNoGuiSort;
 
     @Config.DefaultBoolean(true)
     @Config.Comment("Enable the auto-refill feature.")

--- a/src/main/java/com/cleanroommc/bogosorter/common/config/ConfigGui.java
+++ b/src/main/java/com/cleanroommc/bogosorter/common/config/ConfigGui.java
@@ -181,6 +181,27 @@ public class ConfigGui extends CustomModularScreen {
                         new CycleButtonWidget()
                             .value(
                                 new BoolValue.Dynamic(
+                                    () -> BogoSorterConfig.enableNoGuiSort,
+                                    val -> BogoSorterConfig.enableNoGuiSort = val))
+                            .stateOverlay(TOGGLE_BUTTON)
+                            .disableHoverBackground()
+                            .size(14, 14)
+                            .margin(8, 0)
+                            .background(IDrawable.EMPTY))
+                    .child(
+                        IKey.lang("bogosort.gui.enable_noguiSort")
+                            .asWidget()
+                            .height(14)
+                            .marginLeft(10)
+                            .expanded()))
+            .child(
+                new Row().widthRel(1f)
+                    .height(14)
+                    .margin(0, 2)
+                    .child(
+                        new CycleButtonWidget()
+                            .value(
+                                new BoolValue.Dynamic(
                                     () -> BogoSorterConfig.enableAutoRefill,
                                     val -> BogoSorterConfig.enableAutoRefill = val))
                             .stateOverlay(TOGGLE_BUTTON)

--- a/src/main/resources/assets/bogosorter/lang/en_US.lang
+++ b/src/main/resources/assets/bogosorter/lang/en_US.lang
@@ -14,6 +14,7 @@ bogosort.gui.tab.nbt_sort_rules.name=NBT sort rules
 bogosort.gui.available_sort_rules=Available Sort-Rules
 bogosort.gui.configured_sort_rules=Configured Sort-Rules
 bogosort.gui.enable_hotbarSort=Enable hotbar sorting
+bogosort.gui.enable_noguiSort=Enable sorting via keybind while no GUI is open
 bogosort.gui.enable_refill=Enable auto hotbar refill
 bogosort.gui.refill_comment=Quark is installed. If this option is disabled, theirs might still be enabled. You can find the config at 'Management' -> 'Automatic Tool Restock'.
 bogosort.gui.refill_threshold=Auto refill damage threshold


### PR DESCRIPTION
I set this to be enabled by default and hotbar sorting to be disabled by default to replicate the 2.7 behavior, but if it cant be added before the general release of 2.8 then it should be disabled so that it doesn't start messing up people's hotbars.