### PR TITLE
Prevent moving invalid itemStacks

### DIFF
--- a/src/main/java/com/cleanroommc/bogosorter/ShortcutHandler.java
+++ b/src/main/java/com/cleanroommc/bogosorter/ShortcutHandler.java
@@ -44,7 +44,10 @@ public class ShortcutHandler {
     public static void moveItemStack(EntityPlayer player, Container container, SlotAccessor slot, boolean emptySlot,
         int amount) {
         if (slot == null || slot.callGetStack() == null) return;
+
         ItemStack stack = slot.callGetStack();
+        if (stack.stackSize <= 0) return;
+
         Slot currentSlot = container.getSlot(slot.getSlotNumber());
         if (currentSlot == null) return;
         if (SlotDummyOrCrafting(currentSlot)) {


### PR DESCRIPTION
Add check for stackSize equal or less than zero

This change should be perfectly safe, except if there's an item which use itemStacks inferiors to 0 ? But I'm not aware of such.