### PR TITLE
Change the scan for duplicates

### DIFF
--- a/src/main/java/com/cleanroommc/bogosorter/common/dropoff/InventoryManager.java
+++ b/src/main/java/com/cleanroommc/bogosorter/common/dropoff/InventoryManager.java
@@ -113,10 +113,12 @@ public class InventoryManager {
 
             // Avoid duplicates (double chest halves)
             if (!result.isEmpty()) {
-                InventoryData last = result.get(result.size() - 1);
-                if (last.getEntities()
-                    .contains(te)) {
-                    return;
+                for (int i = 0; i < result.size(); i++) {
+                    InventoryData existingData = result.get(i);
+                    if (existingData.getEntities()
+                        .contains(te)) {
+                        return;
+                    }
                 }
             }
 


### PR DESCRIPTION
Because we changed the scan to only check loaded tiles, this led to the order of the list changing. Previously, it only checked the element behind it in the list, which could lead to false results. Now, it scans the entire list and checks for double chests.