### PR TITLE
Allow bigger item names

### DIFF
--- a/src/main/java/com/cleanroommc/bogosorter/common/sort/ClientSortData.java
+++ b/src/main/java/com/cleanroommc/bogosorter/common/sort/ClientSortData.java
@@ -26,7 +26,7 @@ public class ClientSortData {
 
     public static ClientSortData readFromPacket(PacketBuffer buf) throws IOException {
         int color = buf.readVarIntFromBuffer();
-        String name = buf.readStringFromBuffer(64);
+        String name = buf.readStringFromBuffer(32767);
         ClientSortData sortData = new ClientSortData(color, name);
         for (int i = 0, n = buf.readVarIntFromBuffer(); i < n; i++) {
             sortData.getSlotNumbers()


### PR DESCRIPTION
Also see https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21842#issuecomment-3899869406

This PR fixes a crash where item name is too long. Note that items with a weird name like that shouldn't exist in the first place, but I don't see the harm in handling them correctly instead of crashing.