### PR TITLE
Localize dropoff messages and add translations

### DIFF
--- a/src/main/java/com/cleanroommc/bogosorter/common/network/SDropOffMessage.java
+++ b/src/main/java/com/cleanroommc/bogosorter/common/network/SDropOffMessage.java
@@ -12,6 +12,7 @@ import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.StatCollector;
 
 import com.cleanroommc.bogosorter.BogoSorter;
 import com.cleanroommc.bogosorter.common.config.BogoSorterConfig;
@@ -102,25 +103,20 @@ public class SDropOffMessage implements IPacket {
                 .append(BogoSorter.NAME)
                 .append(EnumChatFormatting.RESET)
                 .append("]: ")
-                .append(EnumChatFormatting.RED)
-                .append(itemsCounter)
-                .append(EnumChatFormatting.RESET)
-                .append(" items moved to ")
-                .append(EnumChatFormatting.RED)
-                .append(affectedContainers)
-                .append(EnumChatFormatting.RESET)
-                .append(" containers of ")
-                .append(EnumChatFormatting.RED)
-                .append(totalContainers)
-                .append(EnumChatFormatting.RESET)
-                .append(" checked in total.");
+                .append(
+                    StatCollector.translateToLocalFormatted(
+                        "bogosort.message.dropoff.items_moved",
+                        EnumChatFormatting.RED + Integer.toString(itemsCounter) + EnumChatFormatting.RESET,
+                        EnumChatFormatting.RED + Integer.toString(affectedContainers) + EnumChatFormatting.RESET,
+                        EnumChatFormatting.RED + Integer.toString(totalContainers) + EnumChatFormatting.RESET));
 
             // Append the quota warning if it happened at least once
             if (quotaReachedCount > 0) {
                 messageBuilder.append(EnumChatFormatting.RED)
-                    .append(" (Quota reached ")
-                    .append(quotaReachedCount)
-                    .append(" times)");
+                    .append(
+                        StatCollector.translateToLocalFormatted(
+                            "bogosort.message.dropoff.quota_reached_times",
+                            Integer.toString(quotaReachedCount)));
             }
 
             Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText(messageBuilder.toString()));

--- a/src/main/java/com/cleanroommc/bogosorter/common/network/SDropOffThrottled.java
+++ b/src/main/java/com/cleanroommc/bogosorter/common/network/SDropOffThrottled.java
@@ -7,6 +7,7 @@ import net.minecraft.client.network.NetHandlerPlayClient;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.StatCollector;
 
 import com.cleanroommc.bogosorter.BogoSorter;
 
@@ -33,7 +34,7 @@ public class SDropOffThrottled implements IPacket {
             + EnumChatFormatting.RESET
             + "]: "
             + EnumChatFormatting.RED
-            + "Dropoff throttled";
+            + StatCollector.translateToLocal("bogosort.message.dropoff.throttled");
 
         Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText(message));
         return null;

--- a/src/main/resources/assets/bogosorter/lang/en_US.lang
+++ b/src/main/resources/assets/bogosorter/lang/en_US.lang
@@ -46,6 +46,10 @@ bogosort.gui.usageticker_arrow=Enable Usage Ticker Arrows
 
 bogosort.command.config_relaod.success=Reloaded sorting config
 
+bogosort.message.dropoff.items_moved=%s items moved to %s containers of %s checked in total.
+bogosort.message.dropoff.quota_reached_times= (Quota reached %s times)
+bogosort.message.dropoff.throttled=Dropoff throttled
+
 bogosort.sortrules.item.mod.name=Mod name
 bogosort.sortrules.item.id.name=Registry name
 bogosort.sortrules.item.meta.name=Meta value

--- a/src/main/resources/assets/bogosorter/lang/ru_RU.lang
+++ b/src/main/resources/assets/bogosorter/lang/ru_RU.lang
@@ -1,6 +1,18 @@
-key.categories.bogosorter=Инвентарь Bogo Sorter
+key.categories.bogosorter=Inventory Bogo Sorter
 key.sort_config=Открыть конфигурацию сортировки
-key.sort=Сортировать инвентарь
+key.sort_nogui=Сортировка инвентаря вне GUI
+key.sort_gui=Сортировка инвентаря в GUI
+key.dropoff=Сбросить
+key.dropoff.tooltip1=Сбросить в ближайшие хранилища
+key.dropoff.tooltip2=CTRL + зажать для перемещения
+key.tooltip.keybind=Сочетание клавиш
+key.bogosorter.controls_button=Настройки сочетания клавиш
+key.bogosorter.move_all_same=Переместить всё одинаковое
+key.bogosorter.move_all=Переместить всё
+key.bogosorter.move_single=Переместить один
+key.bogosorter.move_single_empty=Переместить один в свободный слот
+key.bogosorter.throw_all_same=Сбросить всё одинаковое
+key.bogosorter.throw_all=Сбросить всё
 
 bogosort.gui.title=Конфигурация сортировки
 bogosort.gui.tab.general.name=Общие
@@ -9,15 +21,34 @@ bogosort.gui.tab.item_sort_rules.name=Правила сортировки пре
 bogosort.gui.tab.nbt_sort_rules.name=Правила сортировки NBT
 bogosort.gui.available_sort_rules=Доступные правила сортировки
 bogosort.gui.configured_sort_rules=Настроенные правила сортировки
+bogosort.gui.enable_hotbarSort=Включить сортировку панели быстрого доступа
+bogosort.gui.enable_noguiSort=Включить сортировку по клавише вне GUI
 bogosort.gui.enable_refill=Включить автопополнение панели быстрого доступа
+bogosort.gui.refill_comment=Quark установлен. Если эта опция отключена, их опция может быть включена. Конфигурацию можно найти в разделе 'Управление' -> 'Автопополнение запаса инструментов'.
 bogosort.gui.refill_threshold=Порог урона автопополнения
 bogosort.gui.ascending=По возрастанию
 bogosort.gui.descending=По убыванию
 bogosort.gui.hotbar_scrolling=Включить прокрутку стобцов на панели быстрого доступа
 bogosort.gui.hotbar_scrolling.tooltip=Прокручивание стобцов инвентаря при зажатой клавише ALT
 bogosort.gui.enabled=Включено
+bogosort.gui.button.enabled=Включить кнопки сортировки и настройки в GUI
+bogosort.gui.button.color=Цвет фона кнопок сортировки
+bogosort.gui.dropoff_enable=Включить сброс
+bogosort.gui.dropoffbutton_enable=Показать кнопку сброса в инвентаре
+bogosort.gui.dropoff_render=Показать цели сброса
+bogosort.gui.dropoff_chatmessage=Показать сообщение в чате о сбросе
+bogosort.gui.usageticker_enable=Включить тикер использования
+bogosort.gui.usageticker_mainhand=Включить тикер использования основной руки
+bogosort.gui.usageticker_offhand=Включить тикер использования неосновной руки
+bogosort.gui.usageticker_armor=Включить тикер использования брони
+bogosort.gui.usageticker_arrow=Включить тикер использования стрелок
+
 
 bogosort.command.config_relaod.success=Перезагружен конфиг сортировки
+
+bogosort.message.dropoff.items_moved=%s предметов перемещено в %s контейнеров из %s проверенных.
+bogosort.message.dropoff.quota_reached_times=(квота достигнута %s раз)
+bogosort.message.dropoff.throttled=Сброс предметов ограничен
 
 bogosort.sortrules.item.mod.name=Имя мода
 bogosort.sortrules.item.id.name=Имя реестра
@@ -28,40 +59,40 @@ bogosort.sortrules.item.nbt_size.name=Размер тега NBT
 bogosort.sortrules.item.nbt_has.name=Имеет тег NBT
 bogosort.sortrules.item.nbt_rules.name=Правила NBT
 bogosort.sortrules.item.nbt_all_values.name=Все значения NBT
-bogosort.sortrules.item.count.name=Размер стека
+bogosort.sortrules.item.count.name=Размер стака
 bogosort.sortrules.item.ore_dict.name=Рудный словарь
 bogosort.sortrules.item.material.name=Материал
 bogosort.sortrules.item.ore_prefix.name=Префикс руды
-bogosort.sortrules.item.burn_time.name=Время записи
+bogosort.sortrules.item.burn_time.name=Время горения
 bogosort.sortrules.item.block_type.name=Тип блока
 bogosort.sortrules.item.hunger.name=Голод
 bogosort.sortrules.item.saturation.name=Насыщенность
-bogosort.sortrules.item.emc.name=Значение EMC
+bogosort.sortrules.item.emc.name=EMC значение
 bogosort.sortrules.item.color.name=Цвет
 
 bogosort.sortrules.item.mod.description=Сортирует предметы в алфавитном порядке по имени мода
-bogosort.sortrules.item.id.description=Сортирует элементы в алфавитном порядке по имени в реестре (без мода)
-bogosort.sortrules.item.meta.description=Сортирует элементы численно по их мета-значению
-bogosort.sortrules.item.registry_order.description=Сортирует элементы по порядку в реестре
-bogosort.sortrules.item.display_name.description=Сортирует элементы в алфавитном порядке по отображаемому имени
-bogosort.sortrules.item.nbt_size.description=Сортирует элементы численно по размеру мета-значения NBT-тега
+bogosort.sortrules.item.id.description=Сортирует предметы в алфавитном порядке по имени в реестре (без мода)
+bogosort.sortrules.item.meta.description=Сортирует предметы численно по их мета-значению
+bogosort.sortrules.item.registry_order.description=Сортирует предметы в числовом порядке в реестре
+bogosort.sortrules.item.display_name.description=Сортирует предметы в алфавитном порядке по отображаемому имени
+bogosort.sortrules.item.nbt_size.description=Сортирует предметы численно по размеру мета-значения NBT-тега
 bogosort.sortrules.item.nbt_has.description=Сортирует предметы по признаку наличия или отсутствия тега NBT
-bogosort.sortrules.item.nbt_rules.description=Сортирует элементы на основе настроенных правил сортировки NBT
-bogosort.sortrules.item.nbt_all_values.description=Пытается отсортировать элементы, сравнивая все теги и подтеги nbt
-bogosort.sortrules.item.count.description=Сортирует предметы по размеру стопки
+bogosort.sortrules.item.nbt_rules.description=Сортирует предметы на основе настроенных правил сортировки NBT
+bogosort.sortrules.item.nbt_all_values.description=Пытается отсортировать предметы, сравнивая все теги и подтеги nbt
+bogosort.sortrules.item.count.description=Сортирует предметы по размеру стака
 bogosort.sortrules.item.ore_dict.description=Сортирует предметы в числовом и/или алфавитном порядке по их рудным словарям
 bogosort.sortrules.item.material.description=Сортирует предметы в алфавитном порядке по названию материала (например, железо, золото, медь...)
-bogosort.sortrules.item.ore_prefix.description=Сортирует предметы по их префиксу руды (например, слиток, самородок, пластина, снаряжение...)
-bogosort.sortrules.item.burn_time.description=Сортирует предметы по времени сжигания топлива
-bogosort.sortrules.item.block_type.description=Сортирует предметы на основе типа блока, к которому они относятся (например, полноценный блок, плита, ступеньки и т.д.)
+bogosort.sortrules.item.ore_prefix.description=Сортирует предметы по их префиксу руды (например, слиток, самородок, пластина, шестерня...)
+bogosort.sortrules.item.burn_time.description=Сортирует предметы по времени горения топлива
+bogosort.sortrules.item.block_type.description=Сортирует предметы на основе типа блока, к которому они относятся (например, блок, плита, ступеньки и т.д.)
 bogosort.sortrules.item.hunger.description=Сортирует предметы в числовом порядке по значению восполнения голода
 bogosort.sortrules.item.saturation.description=Сортирует предметы в числовом порядке по значению насыщения
-bogosort.sortrules.item.emc.description==Сортировка элементов по их значению EMC
-bogosort.sortrules.item.color.description==Сортирует элементы в числовом порядке по значению оттенка цвета
+bogosort.sortrules.item.emc.description=Сортировка предметов по их EMC значению
+bogosort.sortrules.item.color.description=Сортирует предметы в числовом порядке по значению оттенка цвета
 
 bogosort.sortrules.nbt.potion.name=Зелья
-bogosort.sortrules.nbt.enchantment.name=Чары
-bogosort.sortrules.nbt.enchantment_book.name=Зачаровать. книги
+bogosort.sortrules.nbt.enchantment.name=Зачарования
+bogosort.sortrules.nbt.enchantment_book.name=Зачарованные книги
 bogosort.sortrules.nbt.gt_circ_config.name=Программируемая схема GT
 bogosort.sortrules.nbt.gt_item_damage.name=Урон инструмента GT
 
@@ -70,3 +101,39 @@ bogosort.sortrules.nbt.enchantment.description=Сортирует зачаров
 bogosort.sortrules.nbt.enchantment_book.description=Сортирует зачарованные книги по эффекту и уровню
 bogosort.sortrules.nbt.gt_circ_config.description=Сортирует программируемые схемы GregTech по их конфигурации
 bogosort.sortrules.nbt.gt_item_damage.description=Сортирует инструменты GregTech по их повреждению
+
+bogosorter.config.dropoff=Настройка сброса
+bogosorter.config.dropoff.enable=Включить сброс
+bogosorter.config.dropoff.scan_radius=Радиус сканирования для сброса (блоки)
+bogosorter.config.dropoff.render=Подсвечивать хранилища
+bogosorter.config.dropoff.render_style=Стиль рендеринга
+bogosorter.config.dropoff.render_fade_out=Затухание рендеринга
+bogosorter.config.dropoff.chat_message=Показывать сообщение в чате о сбросе
+bogosorter.config.dropoff.quota=Drop-off quota (ms)
+bogosorter.config.dropoff.throttle=Drop-off throttle (ms)
+bogosorter.config.dropoff.targets=Фильтр хранилищ (имена)
+
+bogosorter.config.dropoff.button=Настройки кнопки сброса
+bogosorter.config.dropoff.button.x=Положение кнопки X
+bogosorter.config.dropoff.button.y=Положение кнопки Y
+bogosorter.config.dropoff.button.visible=Показывать кнопку сброса
+
+bogosorter.config.usage_ticker=Настройки тикера использования
+bogosorter.config.usage_ticker.enable=Включить тикер использования
+bogosorter.config.usage_ticker.mainhand=Show main hand usage
+bogosorter.config.usage_ticker.offhand=Show off hand usage
+bogosorter.config.usage_ticker.armor=Показать использование брони
+bogosorter.config.usage_ticker.arrow=Настройки стрелок
+bogosorter.config.usage_ticker.arrow.enable=Включить использование стрелок
+bogosorter.config.usage_ticker.arrow.arrowItems=Предметная стрелка
+bogosorter.config.usage_ticker.arrow.bowItems=Предметные скобки
+
+bogosorter.config.sort.sound=Звук нажатия кнопки сортировки 
+bogosorter.config.hotbarsort.enable=Включить сортировку панели быстрого доступа
+bogosorter.config.hotbarswap.enable=Включить замену хотбара
+bogosorter.config.autorefill.enable=Включить автоподмену (Клиентский переключатель)
+bogosorter.config.autorefill.enable_server=Включить автоподмену (Серверный переключатель)
+bogosorter.config.autorefill.damage_threshold=Порог урона автоподмены
+bogosorter.config.preventSplit=Prevent Split for Unstackable Items
+bogosorter.config.button.color=Цвет кнопки сортировки
+bogosorter.config.button.enable=Включить кнопку сортировки


### PR DESCRIPTION
Replace hardcoded dropoff chat text with StatCollector.translateToLocal(/Formatted) in SDropOffMessage and SDropOffThrottled to enable localization (added StatCollector imports). Add new localization keys to en_US.lang and extend/fix many entries in ru_RU.lang for dropoff, GUI, keys and config strings so messages display correctly in different languages.