### PR TITLE
Fix regression to inventory sorting from PR #211

### DIFF
--- a/src/main/java/com/cleanroommc/bogosorter/ClientEventHandler.java
+++ b/src/main/java/com/cleanroommc/bogosorter/ClientEventHandler.java
@@ -22,6 +22,7 @@ import net.minecraftforge.client.event.RenderWorldLastEvent;
 
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.input.Keyboard;
+import org.lwjgl.input.Mouse;
 
 import com.cleanroommc.bogosorter.api.SortRule;
 import com.cleanroommc.bogosorter.client.keybinds.KeyBind;
@@ -38,7 +39,9 @@ import com.cleanroommc.bogosorter.common.sort.ClientSortData;
 import com.cleanroommc.bogosorter.common.sort.GuiSortingContext;
 import com.cleanroommc.bogosorter.common.sort.SlotGroup;
 import com.cleanroommc.bogosorter.common.sort.SortHandler;
+import com.cleanroommc.bogosorter.compat.Mods;
 import com.cleanroommc.bogosorter.compat.ae2.Ae2TerminalSearchAdapter;
+import com.cleanroommc.bogosorter.compat.controlling.ControllingCompat;
 import com.cleanroommc.bogosorter.compat.screen.WarningScreen;
 import com.cleanroommc.bogosorter.mixins.early.minecraft.SlotAccessor;
 import com.cleanroommc.modularui.api.event.KeyboardInputEvent;
@@ -403,6 +406,14 @@ public class ClientEventHandler {
     }
 
     private static boolean Keypress(KeyBinding key) {
-        return key.getKeyCode() != 0 && (key.isPressed() || key.getIsKeyPressed());
+        int keyCode = key.getKeyCode();
+        if (keyCode == 0) return false;
+        if (key.isPressed() || key.getIsKeyPressed()) return true;
+
+        boolean eventPressed = keyCode > 0 ? Keyboard.getEventKeyState() && Keyboard.getEventKey() == keyCode
+            : Mouse.getEventButtonState() && Mouse.getEventButton() == keyCode + 100;
+        if (!eventPressed) return false;
+
+        return !Mods.Controlling.isLoaded() || ControllingCompat.isModifierActive(key);
     }
 }

--- a/src/main/java/com/cleanroommc/bogosorter/compat/controlling/ControllingCompat.java
+++ b/src/main/java/com/cleanroommc/bogosorter/compat/controlling/ControllingCompat.java
@@ -1,0 +1,14 @@
+package com.cleanroommc.bogosorter.compat.controlling;
+
+import net.minecraft.client.settings.KeyBinding;
+
+import com.blamejared.controlling.keybinding.ComboKeyBinding;
+
+public final class ControllingCompat {
+
+    private ControllingCompat() {}
+
+    public static boolean isModifierActive(KeyBinding key) {
+        return key instanceof ComboKeyBinding combo && combo.controlling$isModifierActive();
+    }
+}


### PR DESCRIPTION
## Summary
Fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/26019
Caused by #211 

Ran into this on the detrav PR but forgot you can't do the whole isPressed thing in a GUI because vanilla is weird about it.
I dunno how I missed this because I did test a bunch of scenario.
BTW this isn't just mouse keys that weren't working to sort, keyboard broke too.

This should properly merge making Controlling modifiers works while fixing the regression while inventory is open.


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
