### PR TITLE
feat(client): repeat drop while drop key held

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The Inventory Tweaks code is very unpleasant to work with. I rather write my own
 - configuring of sort rules (open config with K by default)
 - automatically switching out tools wich are about to break
 - automatically refill broken tools or used up items
+- holding the vanilla drop key keeps dropping items, in the world and over a slot in a GUI (configurable delay/interval, toggle in the config)
 - scroll through vertical slots above a hotbar slots while holding ALT
 - several key shortcuts to move items:
   - CTRL + LMB: transfers a single item

--- a/src/main/java/com/cleanroommc/bogosorter/ClientEventHandler.java
+++ b/src/main/java/com/cleanroommc/bogosorter/ClientEventHandler.java
@@ -25,6 +25,7 @@ import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 
 import com.cleanroommc.bogosorter.api.SortRule;
+import com.cleanroommc.bogosorter.client.drop.DropKeyRepeatHandler;
 import com.cleanroommc.bogosorter.client.keybinds.KeyBind;
 import com.cleanroommc.bogosorter.client.keybinds.control.BSKeybinds;
 import com.cleanroommc.bogosorter.client.network.ClientNetworkHandler;
@@ -97,6 +98,7 @@ public class ClientEventHandler {
         if (event.phase == TickEvent.Phase.END) {
             ClientNetworkHandler.drainClientTasks();
             Ae2TerminalSearchAdapter.applyPendingSearch();
+            DropKeyRepeatHandler.onClientTick();
         }
         if (event.phase == TickEvent.Phase.START) {
             ticks++;

--- a/src/main/java/com/cleanroommc/bogosorter/client/drop/DropKeyRepeatHandler.java
+++ b/src/main/java/com/cleanroommc/bogosorter/client/drop/DropKeyRepeatHandler.java
@@ -1,0 +1,116 @@
+package com.cleanroommc.bogosorter.client.drop;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.inventory.Slot;
+
+import com.cleanroommc.bogosorter.ShortcutHandler;
+import com.cleanroommc.bogosorter.client.keybinds.KeyBind;
+import com.cleanroommc.bogosorter.common.config.BogoSorterConfig;
+import com.cleanroommc.bogosorter.mixins.early.minecraft.GuiContainerAccessor;
+
+/**
+ * Backport of the modern Minecraft drop key behaviour: holding the vanilla drop key keeps dropping items after a short
+ * delay. Vanilla handles the initial press, this only adds the repeats.
+ */
+public class DropKeyRepeatHandler {
+
+    private enum Context {
+        NONE,
+        WORLD,
+        GUI
+    }
+
+    private static int heldTicks = 0;
+    private static boolean guiArmed = false;
+    private static GuiScreen armedScreen = null;
+    private static Context lastContext = Context.NONE;
+    private static boolean wasPressed = false;
+    private static boolean worldArmed = false;
+
+    /** Called from the GuiContainer mixin when vanilla drops from the hovered slot. */
+    public static void armGui() {
+        if (!guiArmed || armedScreen != Minecraft.getMinecraft().currentScreen) heldTicks = 0;
+        guiArmed = true;
+        armedScreen = Minecraft.getMinecraft().currentScreen;
+    }
+
+    public static void onClientTick() {
+        Minecraft mc = Minecraft.getMinecraft();
+        int keyCode = mc.gameSettings != null ? mc.gameSettings.keyBindDrop.getKeyCode() : 0;
+        boolean pressed = keyCode != 0 && KeyBind.isKeyPressed(keyCode);
+        // Arm the world path only on a fresh press observed while no screen is open.
+        if (mc.currentScreen == null && pressed && !wasPressed) {
+            worldArmed = true;
+        }
+        wasPressed = pressed;
+        if (!pressed) {
+            reset();
+            return;
+        }
+        if (!BogoSorterConfig.dropKeyRepeat.enableDropKeyRepeat || mc.thePlayer == null) {
+            reset();
+            return;
+        }
+        Context context = getContext(mc);
+        if (context == Context.NONE) {
+            reset();
+            return;
+        }
+        // Each context re-pays the initial delay.
+        if (context != lastContext) {
+            lastContext = context;
+            heldTicks = 0;
+            return;
+        }
+        heldTicks++;
+        int delay = Math.max(0, BogoSorterConfig.dropKeyRepeat.initialDelayTicks);
+        int interval = Math.max(1, BogoSorterConfig.dropKeyRepeat.repeatIntervalTicks);
+        if (heldTicks <= delay || (heldTicks - delay - 1) % interval != 0) return;
+        if (context == Context.WORLD) {
+            dropInWorld(mc);
+        } else {
+            dropInGui(mc);
+        }
+    }
+
+    private static Context getContext(Minecraft mc) {
+        if (mc.currentScreen == null) {
+            guiArmed = false;
+            armedScreen = null;
+            if (!worldArmed || !mc.inGameHasFocus) return Context.NONE;
+            return Context.WORLD;
+        }
+        if (guiArmed && mc.currentScreen == armedScreen && mc.currentScreen instanceof GuiContainer) return Context.GUI;
+        guiArmed = false;
+        armedScreen = null;
+        return Context.NONE;
+    }
+
+    private static void dropInWorld(Minecraft mc) {
+        mc.thePlayer.dropOneItem(GuiScreen.isCtrlKeyDown());
+    }
+
+    private static void dropInGui(Minecraft mc) {
+        GuiContainer gui = (GuiContainer) mc.currentScreen;
+        Slot slot = gui.theSlot;
+        // Nothing to drop, but keep counting so drops resume if the slot refills.
+        if (slot == null || !slot.getHasStack()) return;
+        // Mode-4 clicks require an empty cursor; a held stack would be a guaranteed no-op.
+        if (mc.thePlayer.inventory.getItemStack() != null) return;
+        // Runs from the tick loop, not keyTyped, so SetCanTakeStack may still be stale false from a shortcut;
+        // set it true like ClientEventHandler.handleInput does so SlotMixin lets the client-side click match the
+        // packet we're about to send.
+        ShortcutHandler.SetCanTakeStack = true;
+        ((GuiContainerAccessor) gui).callHandleMouseClick(slot, slot.slotNumber, GuiScreen.isCtrlKeyDown() ? 1 : 0, 4);
+    }
+
+    private static void reset() {
+        heldTicks = 0;
+        guiArmed = false;
+        armedScreen = null;
+        lastContext = Context.NONE;
+        worldArmed = false;
+    }
+}

--- a/src/main/java/com/cleanroommc/bogosorter/client/drop/DropKeyRepeatHandler.java
+++ b/src/main/java/com/cleanroommc/bogosorter/client/drop/DropKeyRepeatHandler.java
@@ -3,10 +3,14 @@ package com.cleanroommc.bogosorter.client.drop;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.client.gui.inventory.GuiContainerCreative;
 import net.minecraft.inventory.Slot;
+
+import org.jetbrains.annotations.Nullable;
 
 import com.cleanroommc.bogosorter.ShortcutHandler;
 import com.cleanroommc.bogosorter.client.keybinds.KeyBind;
+import com.cleanroommc.bogosorter.client.keybinds.control.BSKeybinds;
 import com.cleanroommc.bogosorter.common.config.BogoSorterConfig;
 import com.cleanroommc.bogosorter.mixins.early.minecraft.GuiContainerAccessor;
 
@@ -34,6 +38,16 @@ public class DropKeyRepeatHandler {
         if (!guiArmed || armedScreen != Minecraft.getMinecraft().currentScreen) heldTicks = 0;
         guiArmed = true;
         armedScreen = Minecraft.getMinecraft().currentScreen;
+    }
+
+    /** Bogosorter's throw-all shortcuts take priority over the repeat while their combo is held. */
+    public static boolean isThrowShortcutHeld() {
+        return isHeld(BSKeybinds.getActiveKeyBind(BSKeybinds.THROW_ALL))
+            || isHeld(BSKeybinds.getActiveKeyBind(BSKeybinds.THROW_ALL_SAME));
+    }
+
+    private static boolean isHeld(@Nullable KeyBind keyBind) {
+        return keyBind != null && keyBind.areKeysHeld();
     }
 
     public static void onClientTick() {
@@ -82,7 +96,10 @@ public class DropKeyRepeatHandler {
             if (!worldArmed || !mc.inGameHasFocus) return Context.NONE;
             return Context.WORLD;
         }
-        if (guiArmed && mc.currentScreen == armedScreen && mc.currentScreen instanceof GuiContainer) return Context.GUI;
+        // A throw-all shortcut disarms the repeat; the drop key must be re-pressed to resume.
+        if (guiArmed && mc.currentScreen == armedScreen
+            && mc.currentScreen instanceof GuiContainer
+            && !isThrowShortcutHeld()) return Context.GUI;
         guiArmed = false;
         armedScreen = null;
         return Context.NONE;
@@ -97,8 +114,8 @@ public class DropKeyRepeatHandler {
         Slot slot = gui.theSlot;
         // Nothing to drop, but keep counting so drops resume if the slot refills.
         if (slot == null || !slot.getHasStack()) return;
-        // Mode-4 clicks require an empty cursor; a held stack would be a guaranteed no-op.
-        if (mc.thePlayer.inventory.getItemStack() != null) return;
+        // Mode-4 clicks require an empty cursor, except GuiContainerCreative which drops with a full one.
+        if (mc.thePlayer.inventory.getItemStack() != null && !(gui instanceof GuiContainerCreative)) return;
         // Runs from the tick loop, not keyTyped, so SetCanTakeStack may still be stale false from a shortcut;
         // set it true like ClientEventHandler.handleInput does so SlotMixin lets the client-side click match the
         // packet we're about to send.

--- a/src/main/java/com/cleanroommc/bogosorter/client/keybinds/KeyBind.java
+++ b/src/main/java/com/cleanroommc/bogosorter/client/keybinds/KeyBind.java
@@ -87,6 +87,11 @@ public class KeyBind {
         return this.pressedTick >= 0;
     }
 
+    /** Raw key state, ignoring the event based validator and tick bookkeeping. */
+    public boolean areKeysHeld() {
+        return areAllPressed(this.keys) && areAllNotPressed(this.notKeys);
+    }
+
     public int getTicksPressed() {
         return this.pressedTick < 0 ? -1 : (int) (ClientEventHandler.getTicks() - this.pressedTick);
     }

--- a/src/main/java/com/cleanroommc/bogosorter/common/config/BogoSorterConfig.java
+++ b/src/main/java/com/cleanroommc/bogosorter/common/config/BogoSorterConfig.java
@@ -11,6 +11,9 @@ public class BogoSorterConfig {
     @Config.Comment("DropOff Configuration")
     public static final DropOff dropOff = new DropOff();
 
+    @Config.Comment("Drop Key Repeat Configuration")
+    public static final DropKeyRepeat dropKeyRepeat = new DropKeyRepeat();
+
     @Config.Comment("Usage Ticker Configuration")
     public static final UsageTicker usageTicker = new UsageTicker();
 
@@ -73,6 +76,27 @@ public class BogoSorterConfig {
     @Config.LangKey("bogosorter.config.debug_tools.enable")
     @Config.Sync
     public static boolean enableDebugTools;
+
+    @Config.LangKey("bogosorter.config.dropkeyrepeat")
+    public static class DropKeyRepeat {
+
+        @Config.DefaultBoolean(true)
+        @Config.Comment("Hold the vanilla drop key to keep dropping items (world and container GUIs).")
+        @Config.LangKey("bogosorter.config.dropkeyrepeat.enable")
+        public boolean enableDropKeyRepeat;
+
+        @Config.DefaultInt(5)
+        @Config.RangeInt(min = 0, max = 100)
+        @Config.Comment("Ticks the drop key must stay held before the first repeat.")
+        @Config.LangKey("bogosorter.config.dropkeyrepeat.initial_delay")
+        public int initialDelayTicks;
+
+        @Config.DefaultInt(1)
+        @Config.RangeInt(min = 1, max = 100)
+        @Config.Comment("Ticks between repeated drops while the key is held.")
+        @Config.LangKey("bogosorter.config.dropkeyrepeat.interval")
+        public int repeatIntervalTicks;
+    }
 
     @Config.LangKey("bogosorter.config.ae2")
     public static class Ae2Integration {

--- a/src/main/java/com/cleanroommc/bogosorter/common/config/ConfigGui.java
+++ b/src/main/java/com/cleanroommc/bogosorter/common/config/ConfigGui.java
@@ -421,6 +421,28 @@ public class ConfigGui extends CustomModularScreen {
                     .margin(0, 2)
                     .child(
                         new CycleButtonWidget()
+                            .value(
+                                new BoolValue.Dynamic(
+                                    () -> BogoSorterConfig.dropKeyRepeat.enableDropKeyRepeat,
+                                    val -> BogoSorterConfig.dropKeyRepeat.enableDropKeyRepeat = val))
+                            .stateOverlay(TOGGLE_BUTTON)
+                            .disableHoverBackground()
+                            .size(14, 14)
+                            .margin(8, 0)
+                            .background(IDrawable.EMPTY))
+                    .child(
+                        IKey.lang("bogosort.gui.dropkeyrepeat_enable")
+                            .asWidget()
+                            .height(14)
+                            .marginLeft(10)
+                            .expanded()))
+            .child(
+                Flow.row()
+                    .widthRel(1f)
+                    .height(14)
+                    .margin(0, 2)
+                    .child(
+                        new CycleButtonWidget()
                             .value(new BoolValue.Dynamic(() -> BogoSorterConfig.usageTicker.enableModule, val -> {
                                 BogoSorterConfig.usageTicker.enableModule = val;
                                 UsageTicker.reloadElements();

--- a/src/main/java/com/cleanroommc/bogosorter/mixinplugin/Mixins.java
+++ b/src/main/java/com/cleanroommc/bogosorter/mixinplugin/Mixins.java
@@ -21,6 +21,7 @@ public enum Mixins implements IMixins {
             "minecraft.GuiKeyBindingListKeyEntryAccessor",
             "minecraft.GuiScreenAccessor",
             "minecraft.GuiContainerAccessor",
+            "minecraft.GuiContainerDropKeyMixin",
             "minecraft.GuiEditSignMixin",
             "minecraft.MinecraftMixin")),
     IronChest(new MixinBuilder()

--- a/src/main/java/com/cleanroommc/bogosorter/mixins/early/minecraft/GuiContainerDropKeyMixin.java
+++ b/src/main/java/com/cleanroommc/bogosorter/mixins/early/minecraft/GuiContainerDropKeyMixin.java
@@ -1,0 +1,37 @@
+package com.cleanroommc.bogosorter.mixins.early.minecraft;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.inventory.Slot;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.cleanroommc.bogosorter.client.drop.DropKeyRepeatHandler;
+import com.cleanroommc.bogosorter.client.keybinds.KeyBind;
+import com.cleanroommc.bogosorter.client.keybinds.control.BSKeybinds;
+
+/** Arms drop key repeats only when vanilla itself drops from the hovered slot. */
+@Mixin(GuiContainer.class)
+public abstract class GuiContainerDropKeyMixin {
+
+    @Shadow
+    public Slot theSlot;
+
+    @Inject(method = "keyTyped", at = @At("HEAD"))
+    private void bogosorter$armDropKeyRepeat(char typedChar, int keyCode, CallbackInfo ci) {
+        Minecraft mc = Minecraft.getMinecraft();
+        int dropKey = mc.gameSettings.keyBindDrop.getKeyCode();
+        if (dropKey == 0 || keyCode != dropKey || this.theSlot == null || !this.theSlot.getHasStack()) return;
+        // pick-block bound to the same key wins in vanilla, so no drop happens.
+        if (dropKey == mc.gameSettings.keyBindPickBlock.getKeyCode()) return;
+        // bogosorter's own throw-all shortcuts take priority while held.
+        KeyBind throwAll = BSKeybinds.getActiveKeyBind(BSKeybinds.THROW_ALL);
+        KeyBind throwAllSame = BSKeybinds.getActiveKeyBind(BSKeybinds.THROW_ALL_SAME);
+        if ((throwAll != null && throwAll.isPressed()) || (throwAllSame != null && throwAllSame.isPressed())) return;
+        DropKeyRepeatHandler.armGui();
+    }
+}

--- a/src/main/java/com/cleanroommc/bogosorter/mixins/early/minecraft/GuiContainerDropKeyMixin.java
+++ b/src/main/java/com/cleanroommc/bogosorter/mixins/early/minecraft/GuiContainerDropKeyMixin.java
@@ -11,8 +11,6 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.cleanroommc.bogosorter.client.drop.DropKeyRepeatHandler;
-import com.cleanroommc.bogosorter.client.keybinds.KeyBind;
-import com.cleanroommc.bogosorter.client.keybinds.control.BSKeybinds;
 
 /** Arms drop key repeats only when vanilla itself drops from the hovered slot. */
 @Mixin(GuiContainer.class)
@@ -29,9 +27,7 @@ public abstract class GuiContainerDropKeyMixin {
         // pick-block bound to the same key wins in vanilla, so no drop happens.
         if (dropKey == mc.gameSettings.keyBindPickBlock.getKeyCode()) return;
         // bogosorter's own throw-all shortcuts take priority while held.
-        KeyBind throwAll = BSKeybinds.getActiveKeyBind(BSKeybinds.THROW_ALL);
-        KeyBind throwAllSame = BSKeybinds.getActiveKeyBind(BSKeybinds.THROW_ALL_SAME);
-        if ((throwAll != null && throwAll.isPressed()) || (throwAllSame != null && throwAllSame.isPressed())) return;
+        if (DropKeyRepeatHandler.isThrowShortcutHeld()) return;
         DropKeyRepeatHandler.armGui();
     }
 }

--- a/src/main/resources/assets/bogosorter/lang/en_US.lang
+++ b/src/main/resources/assets/bogosorter/lang/en_US.lang
@@ -42,6 +42,7 @@ bogosort.gui.button.enabled=Enable sort and config buttons in GUI's
 bogosort.gui.button.color=Background color of sort buttons
 bogosort.gui.dropoff_enable=Enable Dropoff
 bogosort.gui.dropoff_hotbar_enable=Enable Hotbar Dropoff
+bogosort.gui.dropkeyrepeat_enable=Hold Drop Key To Keep Dropping
 bogosort.gui.dropoffbutton_enable=Show Dropoff Button in Inventory
 bogosort.gui.dropoff_render=Show Dropoff Targets
 bogosort.gui.dropoff_chatmessage=Show Dropoff Chat Message
@@ -161,3 +162,8 @@ bogosorter.config.ae2.debug_logging=AE2 integration debug logging
 bogosorter.tooltip.amount_in_system=Amount in System: %s
 bogosorter.tooltip.amount_out_of_range=Amount in System: Out of Range!
 bogosorter.tooltip.amount_checking=Amount in System: Checking...
+
+bogosorter.config.dropkeyrepeat=Drop Key Repeat
+bogosorter.config.dropkeyrepeat.enable=Hold drop key to keep dropping
+bogosorter.config.dropkeyrepeat.initial_delay=Ticks held before first repeat
+bogosorter.config.dropkeyrepeat.interval=Ticks between repeats


### PR DESCRIPTION
## Summary
Backport of modern MC: vanilla drops on press, repeat starts after a delay at one drop per tick. Works in world and over a hovered slot. GUI repeats are armed by a GuiContainer.keyTyped mixin, so screens that consume the key first (anvil rename, NEI search) never trigger drops. Rate and delay configurable, toggle defaults on, 5t delay.

Preview in latest daily

https://github.com/user-attachments/assets/f85809d9-7fa8-41bb-9983-660367a08687





## Checklist
- [X] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
