### PR TITLE
Fix incorrect AE2 presence check

### DIFF
--- a/src/main/java/com/cleanroommc/bogosorter/BogoSorter.java
+++ b/src/main/java/com/cleanroommc/bogosorter/BogoSorter.java
@@ -55,20 +55,6 @@ public class BogoSorter {
     public static final XSTR RND = new XSTR();
     public static final Logger LOGGER = LogManager.getLogger();
 
-    private static final boolean AE2_PRESENT;
-
-    // checks if class is present to avoid NoClassDefFoundError when trying to access AE2 code on a server without AE2
-    static {
-        boolean present;
-        try {
-            Class.forName("appeng.api.storage.IStorageGrid");
-            present = true;
-        } catch (Throwable t) {
-            present = false;
-        }
-        AE2_PRESENT = present;
-    }
-
     @Mod.EventHandler
     public void onPreInit(FMLPreInitializationEvent event) {
         FMLCommonHandler.instance()
@@ -147,7 +133,7 @@ public class BogoSorter {
     @SubscribeEvent
     public void onPlayerLogout(PlayerEvent.PlayerLoggedOutEvent event) {
         // if ae2 not detected, just return
-        if (!AE2_PRESENT) return;
+        if (!Mods.Ae2.isLoaded()) return;
 
         if (event.player instanceof EntityPlayerMP) {
             Ae2AmountService.clearPlayer((EntityPlayerMP) event.player);


### PR DESCRIPTION
## Summary
Fixes https://discord.com/channels/181078474394566657/522098956491030558/1531266984346521711

`appeng.api.networking.storage.IStorageGrid` is the correct path, not `appeng.api.storage.IStorageGrid`, but `Mods.Ae2.isLoaded()` should be enough for the check in the first place.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
