### PR TITLE
Add sorting for WitchingGadgets Bag and Cloak

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -68,6 +68,7 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:BetterStorage:0.14.0.0:dev")
     compileOnly("com.github.GTNewHorizons:Chisel:2.17.26-GTNH:dev")
     compileOnly("com.cubefury.vendingmachine:VendingMachine:0.4.89:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:WitchingGadgets:1.8.48-GTNH:dev")
 
     //for Tinkers Construct arrows
     compileOnly("com.github.GTNewHorizons:Battlegear2:1.4.3:dev") { transitive = false }

--- a/src/main/java/com/cleanroommc/bogosorter/mixinplugin/Mixins.java
+++ b/src/main/java/com/cleanroommc/bogosorter/mixinplugin/Mixins.java
@@ -62,6 +62,13 @@ public enum Mixins implements IMixins {
         .addClientMixins(
             "controlling.MixinGuiNewKeyBindingList",
             "controlling.GuiNewKeyBindingListKeyEntryAccessor")
+    ),
+    WitchingGadgets(new MixinBuilder()
+        .addRequiredMod(TargetedMod.WITCHINGGADGETS)
+        .setPhase(Phase.LATE)
+        .addCommonMixins(
+            "witchinggadgets.MixinContainerBag",
+            "witchinggadgets.MixinContainerCloak")
     );
     // spotless:on
 

--- a/src/main/java/com/cleanroommc/bogosorter/mixinplugin/TargetedMod.java
+++ b/src/main/java/com/cleanroommc/bogosorter/mixinplugin/TargetedMod.java
@@ -17,7 +17,8 @@ public enum TargetedMod implements ITargetMod {
     IRONCHEST(null, "IronChest"),
     NEI("codechicken.nei.asm.NEICorePlugin", "NotEnoughItems"),
     THERMALEXPANSION(null, "ThermalExpansion"),
-    CONTROLLING(null, "controlling");
+    CONTROLLING(null, "controlling"),
+    WITCHINGGADGETS(null, "WitchingGadgets");
 
     private final TargetModBuilder builder;
 

--- a/src/main/java/com/cleanroommc/bogosorter/mixins/late/witchinggadgets/MixinContainerBag.java
+++ b/src/main/java/com/cleanroommc/bogosorter/mixins/late/witchinggadgets/MixinContainerBag.java
@@ -1,0 +1,25 @@
+package com.cleanroommc.bogosorter.mixins.late.witchinggadgets;
+
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+
+import com.cleanroommc.bogosorter.api.IPosSetter;
+import com.cleanroommc.bogosorter.api.ISortableContainer;
+import com.cleanroommc.bogosorter.api.ISortingContextBuilder;
+
+import witchinggadgets.common.gui.ContainerBag;
+
+@Mixin(value = ContainerBag.class, remap = false)
+public abstract class MixinContainerBag implements ISortableContainer {
+
+    @Override
+    public void buildSortingContext(ISortingContextBuilder builder) {
+        builder.addSlotGroup(0, 18, 6)
+            .buttonPosSetter(IPosSetter.TOP_RIGHT_VERTICAL);
+    }
+
+    @Override
+    public @Nullable IPosSetter getPlayerButtonPosSetter() {
+        return IPosSetter.TOP_RIGHT_VERTICAL;
+    }
+}

--- a/src/main/java/com/cleanroommc/bogosorter/mixins/late/witchinggadgets/MixinContainerCloak.java
+++ b/src/main/java/com/cleanroommc/bogosorter/mixins/late/witchinggadgets/MixinContainerCloak.java
@@ -1,0 +1,25 @@
+package com.cleanroommc.bogosorter.mixins.late.witchinggadgets;
+
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+
+import com.cleanroommc.bogosorter.api.IPosSetter;
+import com.cleanroommc.bogosorter.api.ISortableContainer;
+import com.cleanroommc.bogosorter.api.ISortingContextBuilder;
+
+import witchinggadgets.common.gui.ContainerCloak;
+
+@Mixin(value = ContainerCloak.class, remap = false)
+public abstract class MixinContainerCloak implements ISortableContainer {
+
+    @Override
+    public void buildSortingContext(ISortingContextBuilder builder) {
+        builder.addSlotGroup(0, 27, 9)
+            .buttonPosSetter(IPosSetter.TOP_RIGHT_VERTICAL);
+    }
+
+    @Override
+    public @Nullable IPosSetter getPlayerButtonPosSetter() {
+        return IPosSetter.TOP_RIGHT_VERTICAL;
+    }
+}


### PR DESCRIPTION
Bag of Tricks (18), and Cloak of Volumous Pockets (27). Ender bag just opens your vanilla ender chest UI and already has sorting.

[ScreenRecord_20260730_021744.webm](https://github.com/user-attachments/assets/5fc6b3e4-c044-4545-b630-6e7fb0839f03)

fixes #217 

## Checklist
- [X] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [x] This PR requires another PR in order to merge
